### PR TITLE
updated url for cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -U datasets fiftyone
 Then clone the repo:
 
 ```bash
-git clone https://github.com/jacobmarks/export_hf_datasets_to_fiftyone.git
+git clone https://github.com/jacobmarks/huggingface-fiftyone-converters.git
 cd export_hf_datasets_to_fiftyone
 ```
 


### PR DESCRIPTION
The url to clone pointed to a non-existent repo: `git clone https://github.com/jacobmarks/export_hf_datasets_to_fiftyone.git
`

 I think you meant to point to: `https://github.com/jacobmarks/huggingface-fiftyone-converters.git`

